### PR TITLE
Add mini farm game example

### DIFF
--- a/mini-farm-game/game.js
+++ b/mini-farm-game/game.js
@@ -1,0 +1,51 @@
+const canvas = document.getElementById('game');
+const ctx = canvas.getContext('2d');
+
+// ---- Game State ----
+const state = {
+  gold: 0,
+  tiles: [],      // ข้อมูลแต่ละช่องบนแผนที่
+  buildings: [],  // เก็บอาคาร
+};
+
+// สร้างแผนที่พื้นฐาน 20x15
+for (let y = 0; y < 15; y++) {
+  for (let x = 0; x < 20; x++) {
+    state.tiles.push({ x, y, type: 'grass' });
+  }
+}
+
+// ---- Game Loop ----
+function update() {
+  // ตัวอย่าง: เพิ่มทองอัตโนมัติ
+  state.gold += 0.01;
+}
+
+function draw() {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  state.tiles.forEach(tile => {
+    if (tile.type === 'grass') ctx.fillStyle = '#6c9';
+    else if (tile.type === 'farm') ctx.fillStyle = '#cc9';
+    ctx.fillRect(tile.x * 32, tile.y * 32, 32, 32);
+  });
+  state.buildings.forEach(b => {
+    ctx.fillStyle = '#a52a2a';
+    ctx.fillRect(b.x * 32, b.y * 32, 32, 32);
+  });
+  document.getElementById('gold').innerText = Math.floor(state.gold);
+}
+
+function loop() {
+  update();
+  draw();
+  requestAnimationFrame(loop);
+}
+loop();
+
+// ---- UI: สร้างฟาร์ม ----
+document.getElementById('buildFarm').onclick = () => {
+  const tile = state.tiles.find(t => t.type === 'grass');
+  if (!tile) return alert('ไม่มีช่องว่าง');
+  tile.type = 'farm';
+  state.buildings.push({ x: tile.x, y: tile.y, type: 'farm' });
+};

--- a/mini-farm-game/index.html
+++ b/mini-farm-game/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="th">
+<head>
+  <meta charset="UTF-8">
+  <title>Mini Farm Game</title>
+  <style>
+    canvas { border: 1px solid #333; }
+    #ui { margin-top: 10px; }
+  </style>
+</head>
+<body>
+  <canvas id="game" width="640" height="480"></canvas>
+  <div id="ui">
+    <button id="buildFarm">สร้างฟาร์ม</button>
+    ทอง: <span id="gold">0</span>
+  </div>
+  <script src="game.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add simple mini farm game using HTML canvas and JavaScript
- start a basic HTTP server for manual testing

## Testing
- `npm test` (fails: Missing script "test")
- `python3 -m http.server -d mini-farm-game 8001`

------
https://chatgpt.com/codex/tasks/task_e_68ab9de6ffb88325adfdff096822d8a0